### PR TITLE
fix: remove symlink which might be stale or non-relative

### DIFF
--- a/src/karchive.cpp
+++ b/src/karchive.cpp
@@ -915,6 +915,12 @@ bool KArchiveDirectory::copyTo(const QString &dest, bool recursiveCopy) const
                     linkName += QLatin1String(".lnk");
                 }
 #endif
+                // remove the link name in case it exists, might have changed
+                // link target, or replace a fat file with a link
+                if (QFile::exists(linkName)) {
+                    QFile::remove(linkName);
+                }
+
                 QFile symLinkTarget(curEntry->symLinkTarget());
                 if (!symLinkTarget.link(linkName)) {
                     //qCDebug(KArchiveLog) << "symlink(" << curEntry->symLinkTarget() << ',' << linkName << ") failed:" << strerror(errno);


### PR DESCRIPTION
QFile::link will refuse to overwrite an already existing entity in the file system (*), which means that any files which may have been moved and replaced with a link will fail to update. Additionally, if the symlink is non-relative, the source OS might have a different folder structure.

* http://doc.qt.io/qt-5/qfile.html#link

I'd like to get some feedback from you guys, who have a better perspective on wether this is too destructive or wether there are additional safeguards which could improve.