### PR TITLE
respect destName when creating directories

### DIFF
--- a/src/karchive.cpp
+++ b/src/karchive.cpp
@@ -372,7 +372,7 @@ bool KArchive::addLocalDirectory(const QString &path, const QString &destName)
                 if (STAT_METHOD(QFile::encodeName(fileName).constData(), &fi) != -1) {
                     perms = fi.st_mode;
                 }
-                writeDir(file, fileInfo.owner(), fileInfo.group(), perms, fileInfo.lastRead(), fileInfo.lastModified(), fileInfo.birthTime());
+                writeDir(dest, fileInfo.owner(), fileInfo.group(), perms, fileInfo.lastRead(), fileInfo.lastModified(), fileInfo.birthTime());
                 // Recurse
                 addLocalDirectory(fileName, dest);
             }


### PR DESCRIPTION
Currently, (empty) directories are always created in the root of the archive.
```cpp
/* The following structure is used for demonstration purposes:
data
├── emptyDir
└── info.txt
*/

// the empty dir is located under `test.zip/emptyDir`
test_zip.addLocalDirectory("data", ".");

// the empty dir is also located under `test.zip/emptyDir` instead of `test.zip/some/path/emptyDir`
test_zip.addLocalDirectory("data", "./some/path");
```