### PR TITLE
Mark addEntry as deprecated, replaced with addEntryV2.

### DIFF
--- a/src/k7zip.cpp
+++ b/src/k7zip.cpp
@@ -2736,11 +2736,15 @@ bool K7Zip::openArchive(QIODevice::OpenMode mode)
 
         if (e) {
             if (index == -1) {
-                rootDir()->addEntry(e);
+                if (!rootDir()->addEntryV2(e)){
+                    return false;
+                }
             } else {
                 QString path = QDir::cleanPath(fileInfo->path.left(index));
                 KArchiveDirectory *d = findOrCreate(path);
-                d->addEntry(e);
+                if (!d->addEntryV2(e)){
+                    return false;
+                }
             }
         }
     }
@@ -2992,7 +2996,9 @@ bool K7Zip::doWriteDir(const QString &name,
     }
 
     KArchiveDirectory *e = new KArchiveDirectory(this, dirName, perm, mtime, user, group, QString() /*symlink*/);
-    parentDir->addEntry(e);
+    if (!parentDir->addEntryV2(e)){
+        return false;
+    }
 
     return true;
 }

--- a/src/kar.cpp
+++ b/src/kar.cpp
@@ -175,8 +175,9 @@ bool KAr::openArchive(QIODevice::OpenMode mode)
                                                 /*symlink*/ QString(),
                                                 dev->pos(),
                                                 size);
-        rootDir()->addEntry(entry); // Ar files don't support directories, so everything in root
-
+        if (!rootDir()->addEntryV2(entry)){ // Ar files don't support directories, so everything in root
+            return false;
+        }
         dev->seek(dev->pos() + size); // Skip contents
     }
 

--- a/src/karchivedirectory.h
+++ b/src/karchivedirectory.h
@@ -86,6 +86,7 @@ public:
      * Adds a new entry to the directory.
      * Note: this can delete the entry if another one with the same name is already present
      */
+    [[deprecated]]
     void addEntry(KArchiveEntry *); // KF7 TODO: remove
 
     /**
@@ -93,6 +94,7 @@ public:
      * Adds a new entry to the directory.
      * @return whether the entry was added or not. Non added entries are deleted
      */
+    [[nodiscard]]
     bool addEntryV2(KArchiveEntry *); // KF7 TODO: rename to addEntry
 
     /**

--- a/src/krcc.cpp
+++ b/src/krcc.cpp
@@ -137,7 +137,9 @@ void KRcc::KRccPrivate::createEntries(const QDir &dir, KArchiveDirectory *parent
         const QFileInfo info(entryPath);
         if (info.isFile()) {
             KArchiveEntry *entry = new KRccFileEntry(q, fileName, 0444, info.lastModified(), parentDir->user(), parentDir->group(), info.size(), entryPath);
-            parentDir->addEntry(entry);
+            if(!parentDir->addEntryV2(entry)){
+                continue;
+            }
         } else {
             KArchiveDirectory *entry =
                 new KArchiveDirectory(q, fileName, 0555, info.lastModified(), parentDir->user(), parentDir->group(), /*symlink*/ QString());

--- a/src/ktar.cpp
+++ b/src/ktar.cpp
@@ -529,17 +529,16 @@ bool KTar::openArchive(QIODevice::OpenMode mode)
                         delete e;
                     }
                 } else {
-                    rootDir()->addEntry(e);
+                    if (!rootDir()->addEntryV2(e)){
+                        return false;
+                    }
                 }
             } else {
                 // In some tar files we can find dir/./file => call cleanPath
                 QString path = QDir::cleanPath(name.left(pos));
                 // Ensure container directory exists, create otherwise
                 KArchiveDirectory *d = findOrCreate(path);
-                if (d) {
-                    d->addEntry(e);
-                } else {
-                    delete e;
+                if(!d || !d->addEntryV2(e)){
                     return false;
                 }
             }

--- a/src/kzip.cpp
+++ b/src/kzip.cpp
@@ -751,14 +751,18 @@ bool KZip::openArchive(QIODevice::OpenMode mode)
 
             if (entry) {
                 if (pos == -1) {
-                    rootDir()->addEntry(entry);
+                    if (!rootDir()->addEntryV2(entry)){
+                        return false;
+                    }
                 } else {
                     // In some tar files we can find dir/./file => call cleanPath
                     QString path = QDir::cleanPath(name.left(pos));
                     // Ensure container directory exists, create otherwise
                     KArchiveDirectory *tdir = findOrCreate(path);
                     if (tdir) {
-                        tdir->addEntry(entry);
+                        if (!tdir->addEntryV2(entry)){
+                            return false;
+                        }
                     } else {
                         setErrorString(tr("File %1 is in folder %2, but %3 is actually a file.").arg(entryName, path, path));
                         delete entry;


### PR DESCRIPTION
- Mark addEntry as [[deprecated]], mark addEntryV2 as [[nodiscard]].
- Replace all addEntry calls with addEntryV2 and ensure proper handling of return values.